### PR TITLE
feat: allow attaching policy to DataDog AWS role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.2]() (2026-05-08)
+
+### Features
+
+* Add `aws_attached_policy_arns` variable to attach additional managed AWS policy ARNs (e.g. `SecurityAudit`) to the Datadog AWS integration IAM role.
+
 ## [1.0.1]() (2025-08-05)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ No modules.
 | [aws_iam_policy.datadog_aws_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.datadog_aws_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.datadog_aws_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.datadog_aws_integration_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [datadog_integration_aws.sandbox](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.datadog_aws_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -64,6 +65,7 @@ No modules.
 | <a name="input_aws_services_enabled"></a> [aws\_services\_enabled](#input\_aws\_services\_enabled) | A map of AWS services with their enabled/disabled metric collection for specific AWS namespaces for this AWS account only. Reference: https://docs.datadoghq.com/integrations/#cat-aws. | `map(bool)` | `null` | no |
 | <a name="input_datadog_aws_integration_iam_role"></a> [datadog\_aws\_integration\_iam\_role](#input\_datadog\_aws\_integration\_iam\_role) | Name of the IAM role used for integrating Datadog with AWS. | `string` | `"DatadogAWSIntegrationRole"` | no |
 | <a name="input_datadog_permissions"></a> [datadog\_permissions](#input\_datadog\_permissions) | List of AWS IAM permissions required for Datadog integration with AWS services. Reference: https://docs.datadoghq.com/integrations/amazon_web_services/#aws-integration-iam-policy. | `list(string)` | `null` | no |
+| <a name="input_aws_attached_policy_arns"></a> [aws\_attached\_policy\_arns](#input\_aws\_attached\_policy\_arns) | List of AWS policy ARNs to attach to the Datadog AWS integration IAM role (e.g. arn:aws:iam::aws:policy/SecurityAudit). | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,12 @@ resource "aws_iam_role_policy_attachment" "datadog_aws_integration" {
   policy_arn = aws_iam_policy.datadog_aws_integration.arn
 }
 
+resource "aws_iam_role_policy_attachment" "datadog_aws_integration_managed" {
+  for_each   = toset(var.aws_attached_policy_arns)
+  role       = aws_iam_role.datadog_aws_integration.name
+  policy_arn = each.value
+}
+
 /**
 Create and manage Datadog - Amazon Web Services integration.
 version = "~> 3.46.0"

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,9 @@ variable "aws_services_enabled" {
   type        = map(bool)
   default     = null
 }
+
+variable "aws_attached_policy_arns" {
+  description = "List of AWS policy ARNs to attach to the Datadog AWS integration IAM role (e.g. arn:aws:iam::aws:policy/SecurityAudit)."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

### Why
Users need to attach additional managed AWS policies (e.g. `SecurityAudit`) to the Datadog AWS integration IAM role without having to extend the inline policy maintained by this module.

### What
- Added a new `aws_attached_policy_arns` input variable (list of strings, defaults to `[]`).
- Added `aws_iam_role_policy_attachment.datadog_aws_integration_managed` to attach each provided policy ARN to the integration role using `for_each`.
- Updated `README.md` and `CHANGELOG.md` (1.0.2) to document the new variable and resource.

### Solution
Used a separate `aws_iam_role_policy_attachment` resource with `for_each = toset(var.aws_attached_policy_arns)` so additional managed policies can be attached without modifying the existing inline policy. The default empty list keeps the change fully backward compatible.

## Types of Changes
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- `terraform init && terraform validate` against the module.
- Apply with `aws_attached_policy_arns = ["arn:aws:iam::aws:policy/SecurityAudit"]` and verify the policy is attached to the Datadog integration role.
- Apply with the default (empty list) and verify no additional attachment is created and existing behavior is preserved.

## Related Issues
N/A