### PR TITLE
fix: stabilise release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,25 +55,35 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.github-app-token.outputs.token }}
-          ref: ${{ github.head_ref }}
-
+          ref: ${{ github.ref }}
 
       # Extract the first (latest) version mentioned in the changelog
       - name: Extract Version from Changelog
         id: extract_version
         run: |
           VERSION=$(grep -oE '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed 's/^## \[//;s/]$//')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from CHANGELOG.md"
+            exit 1
+          fi
           echo "Extracted version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      # Extract only the changelog content of specified version
+      # Extract only the changelog content for the specified version
       - name: Extract Changelog
         id: changelog
-        uses: nickohold/changelog-version-extractor@v1.0.0
-        with:
-          version_prefix: "## ["
-          version: ${{ env.VERSION }}
-          changelog_path: "./CHANGELOG.md"
+        run: |
+          VERSION="${{ env.VERSION }}"
+          ESCAPED=$(printf '%s' "$VERSION" | sed 's/\./\\./g')
+          CONTENT=$(awk "/^## \[${ESCAPED}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          if [ -z "$CONTENT" ]; then
+            echo "::error::Could not extract changelog for version ${VERSION}"
+            exit 1
+          fi
+          DELIMITER="CHANGELOG_EOF_$RANDOM"
+          echo "changelog<<${DELIMITER}" >> $GITHUB_OUTPUT
+          printf '%s\n' "$CONTENT" >> $GITHUB_OUTPUT
+          echo "${DELIMITER}" >> $GITHUB_OUTPUT
 
       # Echo the output from the `changelog` step
       - name: Echo the output
@@ -87,6 +97,6 @@ jobs:
         with:
           tag_name: "v${{ env.VERSION }}"
           release_name: "v${{ env.VERSION }}"
-          body: "${{ steps.changelog.outputs.changelog }}"
+          body: ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: false


### PR DESCRIPTION
## Summary

Fix the release workflow which was failing due to a missing GitHub Action and several shell script reliability issues.

### Why

The release pipeline was broken: `nickohold/changelog-version-extractor@v1.0.0` does not exist on GitHub, causing the job to fail at setup before any steps ran. Additional issues in surrounding steps would have caused silent failures or incorrect behaviour even if that action had been resolved.

### What

- Replace the missing `nickohold/changelog-version-extractor` action with an inline shell script
- Fix `github.head_ref` (empty on `push` events) → `github.ref`
- Add `exit 1` guard when version extraction yields an empty string
- Add `exit 1` guard when changelog extraction yields empty content
- Escape dots in the semver string before using it as an `awk` regex pattern
- Use a randomised delimiter (`CHANGELOG_EOF_$RANDOM`) to prevent collision if changelog content contains a bare `EOF` line
- Remove quotes around `body:` in `actions/create-release@v1` to allow multiline content to pass correctly

### Solution

The changelog extraction logic uses `awk` to scan `CHANGELOG.md` for the target version header and print all lines until the next version header. The version string is pre-escaped with `sed` so dots are treated as literals rather than regex wildcards. Output is written to `$GITHUB_OUTPUT` using a randomised heredoc delimiter for safety.

## Types of Changes

- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan

1. Merge a CHANGELOG.md change to `master` (or trigger `workflow_dispatch`) and confirm the Release workflow runs to completion
2. Verify the created GitHub release has the correct tag (`vX.Y.Z`) and body matches the corresponding CHANGELOG section

## Related Issues

Fixes failing CI run: https://github.com/c0x12c/terraform-datadog-aws-integration/actions/runs/26806844870/job/79026540352